### PR TITLE
Add note about autogen.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Currently, there is no MPRIS proxy implemented.
 Installation
 ------------
 
+If you're building directly from git, execute the autogen script at first. This is not be neccessary with a normal release.
+
+    $ ./autogen.sh
+
 Execute the following commands:
 
     $ ./configure


### PR DESCRIPTION
Some other more unexperienced users probably ask later, why there is not `./configure` script.
